### PR TITLE
feat: add /metrcsi to _is_unprotected_routes

### DIFF
--- a/mlflow_oidc_auth/views.py
+++ b/mlflow_oidc_auth/views.py
@@ -152,6 +152,7 @@ def _is_unprotected_route(path: str) -> bool:
             "/login",
             "/callback",
             "/oidc/static",
+            "/metrics",
         )
     )
 


### PR DESCRIPTION
Hi Team, i am using the --expose-prometheus param to get metrics and noticed it is failing due to auth
so i added the /metrics to _is_unprotected_routes 