### PR TITLE
fix: auth_client token generation

### DIFF
--- a/mlflow_oidc_auth/views.py
+++ b/mlflow_oidc_auth/views.py
@@ -674,7 +674,6 @@ def callback():
     # Get the access token from the authorization code
     token_url, headers, body = auth_client.prepare_token_request(
         AppConfig.get_property("OIDC_TOKEN_URL"),
-        authorization_response=request.url,
         redirect_url=AppConfig.get_property("OIDC_REDIRECT_URI"),
         code=_get_request_param("code"),
         client_secret=AppConfig.get_property("OIDC_CLIENT_SECRET"),


### PR DESCRIPTION
The `token_prepare_request` [method](https://github.com/oauthlib/oauthlib/blob/master/oauthlib/oauth2/rfc6749/clients/base.py#L260) for oauth library fails. The code is passing the authorization url without the attributes containing the code value. This raises an error from the oauth library complaining no code was passed. However we do do pass the actual code as a separate parameter. So removing the authorization_url parameter fixes the issue.