### PR TITLE
feat: check access token for group attribute as well; fix #43

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -34,6 +34,7 @@ class AppConfig:
     OIDC_REDIRECT_URI = os.environ.get("OIDC_REDIRECT_URI", None)
     OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", None)
     OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", None)
+    OIDC_AUDIENCE = os.environ.get("OIDC_AUDIENCE", None)
 
     # https://flask-session.readthedocs.io/en/latest/config.html
     SESSION_TYPE = os.environ.get("SESSION_TYPE", "filesystem")

--- a/mlflow_oidc_auth/views.py
+++ b/mlflow_oidc_auth/views.py
@@ -96,6 +96,8 @@ from mlflow_oidc_auth.sqlalchemy_store import SqlAlchemyStore
 
 from mlflow.server import app
 
+import jwt 
+
 # Create the OAuth2 client
 auth_client = WebApplicationClient(AppConfig.get_property("OIDC_CLIENT_ID"))
 store = SqlAlchemyStore()
@@ -724,6 +726,9 @@ def callback():
     is_admin = False
     user_groups = []
 
+    decoded_access_token = jwt.decode(access_token, audience=AppConfig.get_property("OIDC_AUDIENCE"), options={"verify_signature": False})
+    app.logger.debug(f"{decoded_access_token}")
+
     if AppConfig.get_property("OIDC_GROUP_DETECTION_PLUGIN"):
         import importlib
 
@@ -731,7 +736,11 @@ def callback():
             access_token
         )
     else:
-        user_groups = user_data.get(AppConfig.get_property("OIDC_GROUPS_ATTRIBUTE"), [])
+        attr = AppConfig.get_property("OIDC_GROUPS_ATTRIBUTE")
+        if attr in decoded_access_token:
+            user_groups = decoded_access_token[attr]
+        if attr in user_data:
+            user_groups = user_data[attr]
 
     app.logger.debug(f"User groups: {user_groups}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "Flask-Session>=0.7.0",
   "gunicorn<24; platform_system != 'Windows'",
   "alembic<2,!=1.10.0",
+  "pyjwt>=2.9.0,<=3.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This will add the feature of checking the access token for the `OIDC_GROUPS_ATTRIBUTE`. This is useful for cases where the needed value is stored in the access token and not in the user info token