### PR TITLE
feat: token authentication for api access; fix #44

### DIFF
--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -34,6 +34,11 @@ class AppConfig:
     OIDC_REDIRECT_URI = os.environ.get("OIDC_REDIRECT_URI", None)
     OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", None)
     OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", None)
+    OIDC_AUDIENCE = os.environ.get("OIDC_AUDIENCE", None)
+    OIDC_PUBLIC_KEYS_URL = os.environ.get("OIDC_PUBLIC_KEYS_URL", None)
+    OIDC_USERNAME_TOKEN_ATTRIBUTE = os.environ.get("OIDC_USERNAME_TOKEN_ATTRIBUTE", "email")
+    OIDC_SIGNING_ALG = os.environ.get("OIDC_SIGNING_ALG", None) # ES256, EdDSA, PS256, RS256, HS256
+    OIDC_HS256_SECRET = os.environ.get("OIDC_HS256_SECRET", None) # ES256, EdDSA, PS256, RS256, HS256
 
     # https://flask-session.readthedocs.io/en/latest/config.html
     SESSION_TYPE = os.environ.get("SESSION_TYPE", "filesystem")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
   "Flask-Session>=0.7.0",
   "gunicorn<24; platform_system != 'Windows'",
   "alembic<2,!=1.10.0",
+  "pyjwt[crypto]>=2.9.0,<3.0.0"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This Pr adds the feature of validating an OAuth/OIDC access token in the `Authorization` header for authentication. First the presence of a token is checked, then its validity. In case of failure, the original basic auth check is performed. At the moment, I tested it with Keycloak as the Identity Provider and RS256 signed tokens and the public keys that are exposed by keyloack under `/protocol/openid-connect/certs` 