### PR TITLE
feat: add `OIDC_ALLOW_ALL_USERS` , allow all users to access, even those not in the allowed groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The plugin required the following environment variables but also supported `.env
 | OIDC_SCOPE | OIDC scope |
 | OIDC_GROUP_NAME | User group name to be allowed login to MLFlow, currently supported groups in OIDC claims and Microsoft Entra ID groups |
 | OIDC_ADMIN_GROUP_NAME | User group name to be allowed login to MLFlow manage and define permissions, currently supported groups in OIDC claims and Microsoft Entra ID groups |
+| OIDC_ALLOW_ALL_USERS | Allow all users to log in, even if they are not in OIDC_ADMIN_GROUP_NAME and OIDC_GROUP_NAME |
 | OIDC_AUTHORIZATION_URL | OIDC Auth URL (if discovery URL is not defined) |
 | OIDC_TOKEN_URL         | OIDC Token URL (if discovery URL is not defined) |
 | OIDC_USER_URL          | OIDC User info URL (if discovery URL is not defined) |

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ OIDC_DISCOVERY_URL = 'https://<your_domain>.okta.com/.well-known/openid-configur
 OIDC_CLIENT_SECRET ='<super_secret>'
 OIDC_CLIENT_ID ='<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Okta"
+# Please note that for some OAuth2 providers like GitLab, use spaces instead of commas to separate scopes.
+# If there is a scope-related error, please confirm the string format
 OIDC_SCOPE = "openid,profile,email,groups"
 OIDC_GROUP_NAME = "mlflow-users-group-name"
 OIDC_ADMIN_GROUP_NAME = "mlflow-admin-group-name"

--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ OIDC_DISCOVERY_URL = 'https://<your_domain>.okta.com/.well-known/openid-configur
 OIDC_CLIENT_SECRET ='<super_secret>'
 OIDC_CLIENT_ID ='<client_id>'
 OIDC_PROVIDER_DISPLAY_NAME = "Login with Okta"
-# Please note that for some OAuth2 providers like GitLab, use spaces instead of commas to separate scopes.
-# If there is a scope-related error, please confirm the string format
 OIDC_SCOPE = "openid,profile,email,groups"
 OIDC_GROUP_NAME = "mlflow-users-group-name"
 OIDC_ADMIN_GROUP_NAME = "mlflow-admin-group-name"
@@ -82,6 +80,8 @@ OIDC_ADMIN_GROUP_NAME = "mlflow_admins_group_name"
 ```
 
 > please note, that for getting group membership information, the application should have "GroupMember.Read.All" permission
+
+> Please note that for some OAuth2 providers like GitLab, use spaces instead of commas to separate scopes. If there is a scope-related error, please confirm the string format.
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The plugin required the following environment variables but also supported `.env
 | OIDC_GROUP_DETECTION_PLUGIN | OIDC plugin to detect groups |
 | OIDC_PROVIDER_DISPLAY_NAME | any text to display |
 | OIDC_SCOPE | OIDC scope |
+| OIDC_GROUPS_ATTRIBUTE | If the group name field in userinfo is not `groups`, specify its json key |
 | OIDC_GROUP_NAME | User group name to be allowed login to MLFlow, currently supported groups in OIDC claims and Microsoft Entra ID groups |
 | OIDC_ADMIN_GROUP_NAME | User group name to be allowed login to MLFlow manage and define permissions, currently supported groups in OIDC claims and Microsoft Entra ID groups |
 | OIDC_ALLOW_ALL_USERS | Allow all users to log in, even if they are not in OIDC_ADMIN_GROUP_NAME and OIDC_GROUP_NAME |

--- a/mlflow_oidc_auth/config.py
+++ b/mlflow_oidc_auth/config.py
@@ -1,11 +1,11 @@
 import os
 import secrets
-import requests
 import secrets
 import importlib
 
 from dotenv import load_dotenv
 from mlflow.server import app
+from mlflow_oidc_auth.string_utils import strtobool
 
 load_dotenv()  # take environment variables from .env.
 app.logger.setLevel(os.environ.get("LOG_LEVEL", "INFO"))
@@ -25,6 +25,7 @@ class AppConfig:
         self.OIDC_REDIRECT_URI = os.environ.get("OIDC_REDIRECT_URI", None)
         self.OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", None)
         self.OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", None)
+        self.OIDC_ALLOW_ALL_USERS  =  bool(strtobool(os.environ.get("OIDC_ALLOW_ALL_USERS", "False")))
 
         # session
         self.SESSION_TYPE = os.environ.get("SESSION_TYPE", "cachelib")

--- a/mlflow_oidc_auth/string_utils.py
+++ b/mlflow_oidc_auth/string_utils.py
@@ -1,0 +1,13 @@
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return 1
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return 0
+    else:
+        raise ValueError("invalid truth value %r" % (val,))

--- a/scripts/init-dev-env.sh
+++ b/scripts/init-dev-env.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Script to initialize/reset the development environment
+
+# Remove auth database
+if [ -f "auth.db" ]; then
+    rm auth.db
+    echo "Removed auth.db"
+fi
+
+# Remove Flask session cache
+if [ -d "/tmp/flask_session" ]; then
+    rm -rf /tmp/flask_session/*
+    echo "Cleared /tmp/flask_session"
+fi
+
+# Remove Flask session cache
+if [ -d "/tmp/flask_cache/" ]; then
+    rm -rf /tmp/flask_cache/*
+    echo "Cleared /tmp/flask_cache/"
+fi
+
+# Remove MLflow runs
+if [ -d "mlruns" ]; then
+    rm -rf mlruns
+    echo "Removed mlruns directory"
+fi
+
+# Optional: Recreate necessary directories
+mkdir -p /tmp/flask_session
+mkdir -p /tmp/flask_cache/
+
+echo "Environment initialization complete."

--- a/web-ui/src/styles.scss
+++ b/web-ui/src/styles.scss
@@ -4,4 +4,4 @@ html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 
 /* Importing Bootstrap SCSS file. */
-@import '~bootstrap/scss/bootstrap';
+@import 'bootstrap/scss/bootstrap';


### PR DESCRIPTION
In this PR:

- Add OIDC_ALLOW_ALL_USERS to allow all users to access. 
Motivation: Assuming there is a self-hosted gitlab in the organization, all users in gitlab should have authorized to access MLFlow. Save the trouble of manually adding them to the group one by one

- Added a script to initialize the development environment.(clear authorized user data)
- Add `strtobool` function, avoiding dependencies on distutils
- Avoid warnings: `Usage of '~' in imports is deprecated.`
- Fix bugs: If there is no `groups` field in the `id token` and `userinfo`, HTTP 500 will be caused