### PR TITLE
fix: ui components missing in release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ basic-auth = "mlflow_oidc_auth.client:AuthServiceClient"
 [tool.setuptools.package-data]
 mlflow_oidc_auth = [
   "db/migrations/alembic.ini",
-  "menu.html",
+  "hack/menu.html",
   "static/*",
   "templates/*",
   "ui/*",

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 export MLFLOW_OIDC_AUTH_VERSION=${1:-0.0.0.dev0}
-pushd web-ui
-yarn install
-yarn release
-popd
+pushd web-ui &&\
+yarn install &&\
+yarn release &&\
+popd &&\
 python -m build

--- a/web-ui/angular.json
+++ b/web-ui/angular.json
@@ -39,7 +39,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "10mb"
                 },
                 {
                   "type": "anyComponentStyle",


### PR DESCRIPTION
Some UI components were missing in the wheel. This is because the angular max error size was too low so it failed building, however the CI script was also not strict enough, so it was able to continue the other commands even though exit code 1 was return on the yarn build command.

Since https://github.com/data-platform-hq/mlflow-oidc-auth/pull/54 menu.html also wasn't included anymore during the build

- closes https://github.com/data-platform-hq/mlflow-oidc-auth/issues/60
- closes https://github.com/data-platform-hq/mlflow-oidc-auth/issues/49