### PR TITLE
Resolves the issue of a missing "email" key in the token handling logic 

### DIFF
--- a/mlflow_oidc_auth/views/authentication.py
+++ b/mlflow_oidc_auth/views/authentication.py
@@ -29,8 +29,11 @@ def callback():
     token = get_oauth_instance(app).oidc.authorize_access_token()
     app.logger.debug(f"Token: {token}")
     session["user"] = token["userinfo"]
+    
+    # Use the email key from the userinfo response
+    email = token["userinfo"].get("email")
 
-    email = token["userinfo"]["email"]
+    #email = token["userinfo"]["email"]
     if email is None:
         return "No email provided", 401
     display_name = token["userinfo"]["name"]

--- a/web-ui/src/app/features/home-page/components/home-page/home-page.component.html
+++ b/web-ui/src/app/features/home-page/components/home-page/home-page.component.html
@@ -5,9 +5,6 @@
   <button mat-flat-button aria-label="login" color="primary" (click)="showAccessKeyModal()">
     <span>Create access key</span>
   </button>
-  <button mat-flat-button aria-label="login" color="primary" (click)="showAccessKeyModal()">
-    <span>Publish to Zenodo</span>
-  </button>
 </div>
 
 <div>

--- a/web-ui/src/app/features/home-page/components/home-page/home-page.component.html
+++ b/web-ui/src/app/features/home-page/components/home-page/home-page.component.html
@@ -5,6 +5,9 @@
   <button mat-flat-button aria-label="login" color="primary" (click)="showAccessKeyModal()">
     <span>Create access key</span>
   </button>
+  <button mat-flat-button aria-label="login" color="primary" (click)="showAccessKeyModal()">
+    <span>Publish to Zenodo</span>
+  </button>
 </div>
 
 <div>


### PR DESCRIPTION
Previously, the email key was not being accessed correctly, which caused issues when processing tokens that had the email field nested under the "userinfo" json object.

This bug was only in version 3.2.0, when significant changes have been applied.
Instead, in v2.0.0 was working correctly (same idP being used, just the way how the "email" attribute/field is handled between the two different code versions changed)